### PR TITLE
Fixing some bugs; funcshion.sh; support stdout for filenames; support…

### DIFF
--- a/funcshion.awk
+++ b/funcshion.awk
@@ -5,22 +5,25 @@ BEGIN {
   for ( item in directoryNameSplit ) ++arrayLength
 
   split(directoryNameSplit[arrayLength], fileNameSplit, ".")
-  dirPath = length(path) > 0 ? path : ENVIRON["PWD"]
+  dirPath = length(path) > 0 ? path : "/tmp"
   dirName = length(subdir) > 0 ? subdir : fileNameSplit[1]
   outputDirectory = dirPath "/" dirName
 
   system("mkdir -p " outputDirectory)
 }
 
-match($0, /^(func(tion)?)? ?[a-zA-Z_][a-zA-Z0-9_]* ?(\(\.*\))? ?{/) {
-  if ( match($1, /func(tion)?/) ) {
+match($0, /^(func(tion)? )?[a-zA-Z_][a-zA-Z0-9_]* ?(\(\.*\))? ?{/) {
+  if ( match($1 $2, /func(tion)? /) ) {
     functionName = $2
   }
   else {
     functionName = $1
   }
-  sanitizedName = tolower(match(functionName, /\(/) ? substr(functionName, 1, length(functionName)-2) : functionName)
-  inFunction = 1
+  split(functionName, splitFunctionName, "(")
+  sanitizedName = splitFunctionName[1]
+  if ( length(specificFunction) == 0 || tolower(specificFunction) ~ tolower(functionName) ) {
+    inFunction = 1
+  }
 }
 
 inFunction {
@@ -29,8 +32,13 @@ inFunction {
 }
 
 /^}$/ {
-  fullPath = outputDirectory "/" sanitizedName
-  inFunction = 0
-  print functionBody > fullPath
-  functionBody = ""
+  if ( inFunction == 1 ) {
+    fullPath = outputDirectory "/" sanitizedName
+    inFunction = 0
+    print functionBody > fullPath
+    if ( stdout == 1 ) {
+      print fullPath
+    }
+    functionBody = ""
+  }
 }

--- a/funcshion.sh
+++ b/funcshion.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+funcshion() {
+FILES=""
+while test $# -gt 0;
+    do
+    case "$1"
+        in
+        -f)
+            shift
+            FUNCTION="$1"
+            shift
+		    ;;
+        *)
+            FILES="$FILES $1"
+            shift
+            ;;
+    esac
+done
+
+while FILE in $FILES; do
+    runAwk $FILE
+done
+
+}
+
+# funcshion src/directory/test.sh
+runAwk() {
+if [ -z "$FUNCTION" ]; then
+    awk -f funcshion.awk $1
+else
+    awk -f function.awk -v specificFunction=$FUNCTION $1
+fi
+}


### PR DESCRIPTION
… specific function export

Fixed some bugs:
* If a function starts with "func" it would return the name "{"
* Functions are actually anchored to the start

We need a wrapper for the awk script - but it is optional to use.

The default output path is now /tmp instead of $(pwd)

You can now source an output file to run a function:
```
source $(awk -f funcshion.awk -v stdout=1 -v specificFunction=runawk funcshion.sh) ; runAwk
```